### PR TITLE
linux.sh installs on local bin instead

### DIFF
--- a/install/linux.sh
+++ b/install/linux.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
-sudo cp bin/linux/momoisay /usr/bin/
-sudo chmod +x /usr/bin/momoisay
+
+sudo cp bin/linux/momoisay /usr/local/bin/
+sudo chmod +x /usr/local/bin/momoisay


### PR DESCRIPTION
This is for noobs like me who doesn't know how to set up their PATH and choose a DE that requires you to set up your path manually (Hyprland) >:)

Past installer only makes momoisay accessible through sudo command, which is very trivial.

PS: I'm very noob when it comes to anything linux related, but I just wanna give feedback when i think it helps even for a very little bit.